### PR TITLE
sepolicy: move to coredomain some domains

### DIFF
--- a/common/private/mkfs.te
+++ b/common/private/mkfs.te
@@ -1,5 +1,5 @@
-type mkfs, domain;
-type mkfs_exec, exec_type, file_type;
+type mkfs, domain, coredomain;
+type mkfs_exec, exec_type, file_type , vendor_file_type;
 
 init_daemon_domain(mkfs)
 

--- a/common/private/sysinit.te
+++ b/common/private/sysinit.te
@@ -1,4 +1,4 @@
-type sysinit, domain;
+type sysinit, coredomain, domain;
 type sysinit_exec, exec_type, file_type;
 
 # Allow for transition from init domain to sysinit


### PR DESCRIPTION
and use vendor_file_type to allow execution from vendor in treble builds

Signed-off-by: klozz <klozz707@gmail.com>