### PR TITLE
Revert "sepolicy: Use custom ADB over network property"

### DIFF
--- a/common/private/property.te
+++ b/common/private/property.te
@@ -1,1 +1,0 @@
-type adbtcp_prop, property_type;

--- a/common/private/property_contexts
+++ b/common/private/property_contexts
@@ -1,1 +1,0 @@
-adb.network.port              u:object_r:adbtcp_prop:s0

--- a/common/private/system.te
+++ b/common/private/system.te
@@ -1,2 +1,0 @@
-# allow adb related properties to be set
-allow system_server adbtcp_prop:property_service set;


### PR DESCRIPTION
This reverts commit 7e43c41190a13b742adece9962599764419bc1fe.

Revert "sepolicy: Fix permissions for service.adb.tcp.port"

This reverts commit 4989681dd7476bd217f8aee3ffb102e33ac7fc8a.

Revert "sepolicy: Allow SystemServer to set service.adb.tcp.* properties"

This reverts commit 67008ac5531ad3fa30a1ab8beea407991ac2f2fc.